### PR TITLE
🐛 fix: prevent brownout issues by delaying vibration motor initializa…

### DIFF
--- a/src/modules/ExternalNotificationModule.h
+++ b/src/modules/ExternalNotificationModule.h
@@ -69,6 +69,8 @@ class ExternalNotificationModule : public SinglePortModule, private concurrency:
 
     bool isMuted = false;
 
+    bool vibraMotorInitialized = false;
+
     virtual AdminMessageHandleResult handleAdminMessageForModule(const meshtastic_MeshPacket &mp,
                                                                  meshtastic_AdminMessage *request,
                                                                  meshtastic_AdminMessage *response) override;

--- a/variants/nrf52840/gat562_mesh_trial_tracker/variant.cpp
+++ b/variants/nrf52840/gat562_mesh_trial_tracker/variant.cpp
@@ -36,8 +36,8 @@ void initVariant()
     pinMode(PIN_LED1, OUTPUT);
     ledOff(PIN_LED1);
 
-    pinMode(PIN_LED2, OUTPUT);
-    ledOff(PIN_LED2);
+//    pinMode(PIN_LED2, OUTPUT);
+//    ledOff(PIN_LED2);
 
     // 3V3 Power Rail
     pinMode(PIN_3V3_EN, OUTPUT);

--- a/variants/nrf52840/gat562_mesh_trial_tracker/variant.h
+++ b/variants/nrf52840/gat562_mesh_trial_tracker/variant.h
@@ -51,7 +51,7 @@ extern "C" {
 
 // LEDs
 #define PIN_LED1 (35)
-#define PIN_LED2 (36)
+#define PIN_LED2 -1
 
 #define LED_BUILTIN PIN_LED1
 #define LED_CONN PIN_LED2
@@ -161,6 +161,7 @@ static const uint8_t SCK = PIN_SPI_SCK;
 #define PIN_WIRE_SCL (14)
 
 // QSPI Pins
+/*
 #define PIN_QSPI_SCK 3
 #define PIN_QSPI_CS 26
 #define PIN_QSPI_IO0 30
@@ -171,6 +172,7 @@ static const uint8_t SCK = PIN_SPI_SCK;
 // On-board QSPI Flash
 #define EXTERNAL_FLASH_DEVICES W25Q16JV_IQ
 #define EXTERNAL_FLASH_USE_QSPI
+*/
 
 /* @note RAK5005-O GPIO mapping to RAK4631 GPIO ports
    RAK5005-O <->  nRF52840


### PR DESCRIPTION
- Implement lazy initialization for vibration motor in ExternalNotificationModule
- Initialize vibration motor pin only on first use to avoid power draw during boot
- Disable LED2 and QSPI flash on GAT562 variant to reduce power consumption
- Add vibraMotorInitialized flag to track initialization state