### PR TITLE
feat:add Bootloader selection in shutdown/reboot menu

### DIFF
--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -717,6 +717,9 @@ void Power::reboot()
 #if defined(ARCH_ESP32)
     ESP.restart();
 #elif defined(ARCH_NRF52)
+    if (nrf52_GPREGRET != 0x00) {
+        NRF_POWER->GPREGRET = nrf52_GPREGRET; // some device will reboot after GPREGRET was set.
+    }
     NVIC_SystemReset();
 #elif defined(ARCH_RP2040)
     rp2040.reboot();

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -708,7 +708,18 @@ int32_t Screen::runOnce()
     }
 #endif
     if (!NotificationRenderer::isOverlayBannerShowing() && rebootAtMsec != 0) {
+#ifdef ARCH_NRF52
+        switch (nrf52_GPREGRET) {
+        case 0x00:
+            showSimpleBanner("Rebooting...", 0);
+            break;
+        case 0x57:
+            showSimpleBanner("Bootloader mode\nPower cycle to exit.", 0);
+            break;
+        };
+#else
         showSimpleBanner("Rebooting...", 0);
+#endif
     }
 
     // Process incoming commands.

--- a/src/graphics/draw/MenuHandler.h
+++ b/src/graphics/draw/MenuHandler.h
@@ -21,6 +21,7 @@ class menuHandler
         reset_node_db_menu,
         buzzermodemenupicker,
         mui_picker,
+        reset_to_bl,
         tftcolormenupicker,
         brightness_picker,
         reboot_menu,
@@ -82,6 +83,7 @@ class menuHandler
     static void saveUIConfig();
     static void keyVerificationInitMenu();
     static void keyVerificationFinalPrompt();
+    static void resetToBL();
     static void BluetoothToggleMenu();
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1505,6 +1505,10 @@ void setup()
 uint32_t rebootAtMsec;   // If not zero we will reboot at this time (used to reboot shortly after the update completes)
 uint32_t shutdownAtMsec; // If not zero we will shutdown at this time (used to shutdown from python or mobile client)
 
+#ifdef ARCH_NRF52
+uint8_t nrf52_GPREGRET = 0x00; // Change value to Enter DFU/Serial/BLEOta;
+#endif
+
 // If a thread does something that might need for it to be rescheduled ASAP it can set this flag
 // This will suppress the current delay and instead try to run ASAP.
 bool runASAP;

--- a/src/main.h
+++ b/src/main.h
@@ -81,6 +81,10 @@ extern uint32_t timeLastPowered;
 extern uint32_t rebootAtMsec;
 extern uint32_t shutdownAtMsec;
 
+#ifdef ARCH_NRF52
+extern uint8_t nrf52_GPREGRET;
+#endif
+
 extern uint32_t serialSinceMsec;
 
 // If a thread does something that might need for it to be rescheduled ASAP it can set this flag


### PR DESCRIPTION
add a bootloader selection for devices that without rst button or rst button hard to access.
make it convient for firmware update via USB DFU.
![f916b303af7d18437fd32bc35cb65dba](https://github.com/user-attachments/assets/ebdaf144-b50d-4b1a-a99e-072c1213d7b4)
![33bbae31e955e949398b4b1ebbd81124](https://github.com/user-attachments/assets/f7bac762-34ed-4f3b-8d4d-13c4d5d3e9ac)
